### PR TITLE
Rename 'GitHub' to 'source' on navbar

### DIFF
--- a/frontend/components/Nav.js
+++ b/frontend/components/Nav.js
@@ -44,7 +44,7 @@ export default function Nav() {
 							href='https://github.com/meeshkan/vanity'
 							target='_blank'
 							rel='noopener noreferrer'
-							title='GitHub'
+							title='source'
 						>
 							GitHub
 						</a>


### PR DESCRIPTION
It's not clear that "github" on the top nav bar means the source code (as there are several references to github on the page). Changed to source.