### PR TITLE
Send sample email when there's insufficient comparison data

### DIFF
--- a/backend/test/utils/metrics.test.js
+++ b/backend/test/utils/metrics.test.js
@@ -56,6 +56,13 @@ test('ingest() ingests metrics', async t => {
 });
 
 test('fetchCurrent() fetches current metrics', async t => {
+	const metrics = await fetchCurrent(t.context.user.id);
+	t.true(Array.isArray(metrics));
+	t.true(metrics.length === USER.selectedRepos.length);
+	metrics.forEach(repo => t.deepEqual(Object.keys(repo), REPO_KEYS));
+});
+
+test('fetchCurrent() fetches current metrics of given repos', async t => {
 	const metrics = await fetchCurrent(t.context.user.id, USER.selectedRepos);
 	t.true(Array.isArray(metrics));
 	t.true(metrics.length === USER.selectedRepos.length);

--- a/backend/test/utils/metrics.test.js
+++ b/backend/test/utils/metrics.test.js
@@ -301,3 +301,8 @@ test.serial('fetchComparison() returns comparison based on selected metric types
 
 	await previousSnapshot.destroy();
 });
+
+test.serial('fetchComparison() returns null without sufficient snapshots', async t => {
+	const comparison = await fetchComparison(t.context.user.id);
+	t.is(comparison, null);
+});

--- a/backend/utils/metrics.js
+++ b/backend/utils/metrics.js
@@ -68,6 +68,14 @@ const ingest = async id => {
 
 const fetchCurrent = async (id, selectedRepos) => {
 	const metrics = await fetchUserRepoStats(id);
+	if (!selectedRepos) {
+		const { User } = require('../models');
+		const { repos } = await User.findByPk(id);
+		selectedRepos = repos
+			.filter(repo => repo.selected)
+			.map(repo => repo.name);
+	}
+
 	return metrics
 		.filter(repo => selectedRepos.includes(repo.name));
 };

--- a/backend/utils/metrics.js
+++ b/backend/utils/metrics.js
@@ -85,6 +85,10 @@ const fetchComparison = async id => {
 		.map(metricType => metricType.name));
 
 	const snapshots = await userSnapshots(id);
+	if (snapshots.length < 2) {
+		return null;
+	}
+
 	const { latest, previous } = subjectedSnapshot(snapshots);
 	return compareSnapshots({ latest, previous })
 		.filter(repo => selectedRepos.has(repo.name))

--- a/backend/workers/queues.js
+++ b/backend/workers/queues.js
@@ -19,6 +19,14 @@ const sendEmailWorker = async job => {
 	const { user } = job.data;
 	user.unsubscriptionToken = await generateToken({ email: user.email, id: user.id });
 	const weekMetrics = await metrics.fetchComparison(user.id);
+	if (!weekMetrics) {
+		const currentMetrics = await metrics.fetchCurrent(user.id);
+		return email.sendSample({
+			user,
+			metrics: currentMetrics
+		});
+	}
+
 	return email.send({
 		user,
 		metrics: weekMetrics,


### PR DESCRIPTION
- When there are insufficient metrics for generating a weekly comparison, send a sample email in place of the weekly one.